### PR TITLE
Convert to use standard Android preferences classes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {
@@ -34,5 +35,7 @@ dependencies {
     compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
+    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.android.support:support-vector-drawable:25.3.1'
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,17 +14,26 @@
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <activity
             android:name=".ConfigurationActivity"
             android:parentActivityName=".MainActivity">
-            <meta-data android:name="android.support.PARENT_ACTIVITY" android:value=".MainActivity" />
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
         </activity>
-<!--
-        <service android:name=".EncouragementService" android:exported="false" />
--->
+        <!--         <service android:name=".EncouragementService" android:exported="false" /> -->
+        <activity
+            android:name=".SettingsActivity"
+            android:label="@string/title_activity_settings"
+            android:parentActivityName=".MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.example.encouragement.MainActivity" />
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/encouragement/AppCompatPreferenceActivity.java
+++ b/app/src/main/java/com/example/encouragement/AppCompatPreferenceActivity.java
@@ -1,0 +1,109 @@
+package com.example.encouragement;
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A {@link android.preference.PreferenceActivity} which implements and proxies the necessary calls
+ * to be used with AppCompat.
+ */
+public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
+
+    private AppCompatDelegate mDelegate;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        getDelegate().installViewFactory();
+        getDelegate().onCreate(savedInstanceState);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        getDelegate().onPostCreate(savedInstanceState);
+    }
+
+    public ActionBar getSupportActionBar() {
+        return getDelegate().getSupportActionBar();
+    }
+
+    public void setSupportActionBar(@Nullable Toolbar toolbar) {
+        getDelegate().setSupportActionBar(toolbar);
+    }
+
+    @Override
+    public MenuInflater getMenuInflater() {
+        return getDelegate().getMenuInflater();
+    }
+
+    @Override
+    public void setContentView(@LayoutRes int layoutResID) {
+        getDelegate().setContentView(layoutResID);
+    }
+
+    @Override
+    public void setContentView(View view) {
+        getDelegate().setContentView(view);
+    }
+
+    @Override
+    public void setContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().setContentView(view, params);
+    }
+
+    @Override
+    public void addContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().addContentView(view, params);
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+        getDelegate().onPostResume();
+    }
+
+    @Override
+    protected void onTitleChanged(CharSequence title, int color) {
+        super.onTitleChanged(title, color);
+        getDelegate().setTitle(title);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        getDelegate().onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        getDelegate().onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        getDelegate().onDestroy();
+    }
+
+    public void invalidateOptionsMenu() {
+        getDelegate().invalidateOptionsMenu();
+    }
+
+    private AppCompatDelegate getDelegate() {
+        if (mDelegate == null) {
+            mDelegate = AppCompatDelegate.create(this, null);
+        }
+        return mDelegate;
+    }
+}

--- a/app/src/main/java/com/example/encouragement/SettingsActivity.java
+++ b/app/src/main/java/com/example/encouragement/SettingsActivity.java
@@ -1,0 +1,207 @@
+package com.example.encouragement;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.EditTextPreference;
+import android.preference.PreferenceActivity;
+import android.support.v7.app.ActionBar;
+import android.preference.PreferenceFragment;
+import android.util.Log;
+import android.view.MenuItem;
+import android.support.v4.app.NavUtils;
+
+import java.util.List;
+
+/**
+ * A {@link PreferenceActivity} that presents a set of application settings. On
+ * handset devices, settings are presented as a single list. On tablets,
+ * settings are split by category, with category headers shown to the left of
+ * the list of settings.
+ * <p>
+ * See <a href="http://developer.android.com/design/patterns/settings.html">
+ * Android Design: Settings</a> for design guidelines and the <a
+ * href="http://developer.android.com/guide/topics/ui/settings.html">Settings
+ * API Guide</a> for more information on developing a Settings UI.
+ */
+public class SettingsActivity extends AppCompatPreferenceActivity {
+
+    private static final String ActivityTag = "SettingsActivity";
+
+    private static final String EncouragementIntervalKey = "pref_encouragement_interval";
+
+    /**
+     * Creates the UI from the saved state
+     * @param savedInstanceState the saved state
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setupActionBar();
+    }
+
+    /**
+     * Helper method to determine if the device has an extra-large screen. For
+     * example, 10" tablets are extra-large.
+     */
+    private static boolean isXLargeTablet(Context context) {
+        return (context.getResources().getConfiguration().screenLayout
+                & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_XLARGE;
+    }
+
+    /**
+     * Set up the {@link android.app.ActionBar}, if the API is available.
+     */
+    private void setupActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            // Show the Up button in the action bar.
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    public boolean onMenuItemSelected(int featureId, MenuItem item) {
+        int id = item.getItemId();
+        if (id == android.R.id.home) {
+            if (!super.onMenuItemSelected(featureId, item)) {
+                NavUtils.navigateUpFromSameTask(this);
+            }
+            return true;
+        }
+        return super.onMenuItemSelected(featureId, item);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean onIsMultiPane() {
+        return isXLargeTablet(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public void onBuildHeaders(List<Header> target) {
+        loadHeadersFromResource(R.xml.pref_headers, target);
+    }
+
+    /**
+     * This method stops fragment injection in malicious applications.
+     * Make sure to deny any unknown fragments here.
+     */
+    protected boolean isValidFragment(String fragmentName) {
+        return PreferenceFragment.class.getName().equals(fragmentName)
+                || EncouragementPreferenceFragment.class.getName().equals(fragmentName);
+    }
+
+    /**
+     * This fragment shows encouragement preferences.
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public static class EncouragementPreferenceFragment
+            extends PreferenceFragment
+            implements OnSharedPreferenceChangeListener {
+
+        /** Format string for encouragement interval summary */
+        private String IntervalSummaryFormat = null;
+
+        /**
+         * Initializes the format string from the string table. This cannot be done before object is
+         * fully constructed, so directly initializing a String constant doesn't work.
+         */
+        private void initializeFormat() {
+            if(IntervalSummaryFormat == null) {
+                IntervalSummaryFormat = getString(R.string.pref_encouragement_interval_summary_format);
+            }
+        }
+
+        /**
+         * Handles event triggered when the app instantiates this preference fragment.
+         *
+         * @param savedInstanceState the saved application state
+         */
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            addPreferencesFromResource(R.xml.pref_encouragement);
+            setHasOptionsMenu(true);
+
+            // Initialize summary to saved value for preference
+            initializeFormat();
+            setSummaryFromValue(EncouragementIntervalKey, IntervalSummaryFormat);
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(MenuItem item) {
+            int id = item.getItemId();
+            if (id == android.R.id.home) {
+                startActivity(new Intent(getActivity(), SettingsActivity.class));
+                return true;
+            }
+            return super.onOptionsItemSelected(item);
+        }
+
+        /**
+         * Handles preference change event to display current setting, in accordance with Android
+         * user experience guidelines.
+         *
+         * @param preferences the shared preferences for the app
+         * @param key the preference key of the preference that changed
+         */
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences preferences, String key) {
+            Log.d(ActivityTag, "Preference change: preference = " + key);
+            if(key.equals(EncouragementIntervalKey)) {
+                initializeFormat();
+                setSummaryFromValue(key, IntervalSummaryFormat);
+            }
+        }
+
+        /**
+         * Handles the event triggered when the app resumes. Registers this SettingsActivity to
+         * receive events when the shared preferences change.
+         */
+        @Override
+        public void onResume() {
+            super.onResume();
+            getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+        }
+
+        /**
+         * Handles the event triggered when the app pauses. Stops this SettingsActivity from
+         * receiving events when the shared preferences change.
+         */
+        @Override
+        public void onPause() {
+            super.onPause();
+            getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+        }
+
+        /**
+         * Sets the summary of an {@code EditTextPreference} to a formatted version of its value.
+         * Requires {@code preferenceKey} to indicate an {@code EditTextPreference}.
+         *
+         * @param preferenceKey the key of an {@code EditTextPreference}
+         * @param format formats the value for display. It must have exactly one format specifier
+         *               for a string. The simplest value is {@code "%s"}.
+         */
+        private void setSummaryFromValue(String preferenceKey, String format) {
+            try {
+                EditTextPreference pref = (EditTextPreference) findPreference(preferenceKey);
+                String summary = String.format(format, pref.getText());
+                pref.setSummary(summary);
+            } catch(Exception ex) {
+                // Do nothing
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_info_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_info_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zm1,15h-2v-6h2v6zm0,-8h-2V7h2v2z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,19 @@
     <string name="units_minutes">Minutes</string>
     <string name="paused">Paused</string>
     <string name="playing">Playing</string>
+
+    <!-- Strings related to Settings -->
+    <string name="title_activity_settings">Settings</string>
+    <string name="pref_header_encouragement">Encouragements</string>
+    <string name="pref_encouragement_enabled_title">Play encouragements</string>
+    <string name="pref_encouragement_enabled_summary">
+        Enables or disables periodic encouragements at fixed intervals. May be
+        distracting for some students.
+    </string>
+    <string name="pref_encouragement_interval_title">Interval</string>
+    <string name="pref_encouragement_interval_dialog_message">
+        Fixed time between encouragement sounds, given in seconds.
+    </string>
+    <string name="pref_encouragement_interval_default">20</string>
+    <string name="pref_encouragement_interval_summary_format">%s seconds</string>
 </resources>

--- a/app/src/main/res/xml/pref_encouragement.xml
+++ b/app/src/main/res/xml/pref_encouragement.xml
@@ -1,0 +1,18 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <SwitchPreference
+        android:key="pref_encouragement_enabled"
+        android:title="@string/pref_encouragement_enabled_title"
+        android:summary="@string/pref_encouragement_enabled_summary"
+        android:defaultValue="true" />
+
+    <EditTextPreference
+        android:key="pref_encouragement_interval"
+        android:title="@string/pref_encouragement_interval_title"
+        android:defaultValue="@string/pref_encouragement_interval_default"
+        android:dialogTitle="@string/pref_encouragement_interval_title"
+        android:dialogMessage="@string/pref_encouragement_interval_dialog_message"
+        android:maxLines="1"
+        android:selectAllOnFocus="true"
+        android:digits="0123456789"
+        android:singleLine="true" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/pref_headers.xml
+++ b/app/src/main/res/xml/pref_headers.xml
@@ -1,0 +1,6 @@
+<preference-headers xmlns:android="http://schemas.android.com/apk/res/android">
+    <header
+        android:fragment="com.example.encouragement.SettingsActivity$EncouragementPreferenceFragment"
+        android:icon="@drawable/ic_info_black_24dp"
+        android:title="@string/pref_header_encouragement" />
+</preference-headers>


### PR DESCRIPTION
Switches from using a custom preferences UI to using the standard Android Preferences classes to handle the UI and persistence.